### PR TITLE
add support for conf files

### DIFF
--- a/languages/ini/config.toml
+++ b/languages/ini/config.toml
@@ -1,6 +1,6 @@
 name = "ini"
 grammar = "ini"
-path_suffixes = ["ini", "conf"]
+path_suffixes = ["ini", "conf", "cfg", "config"]
 line_comments = ["; ", "# "]
 autoclose_before = ":.,=}])>"
 brackets = [

--- a/languages/ini/config.toml
+++ b/languages/ini/config.toml
@@ -1,6 +1,6 @@
 name = "ini"
 grammar = "ini"
-path_suffixes = ["ini"]
+path_suffixes = ["ini", "conf"]
 line_comments = ["; ", "# "]
 autoclose_before = ":.,=}])>"
 brackets = [


### PR DESCRIPTION
.conf files also usually follow the .ini syntax. 

Add support for them in the extension.

Tested with some Telegraf config files (https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md).

I know the name of the extension is very specific, please let me know if you'd prefer I create a new extension.